### PR TITLE
fix(usuário): ajuste função para criar e enviar o e-mail do usuário criado - VLT-153

### DIFF
--- a/app/GraphQL/Mutations/UserMutation.php
+++ b/app/GraphQL/Mutations/UserMutation.php
@@ -9,7 +9,7 @@ use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 final class UserMutation
 {
-    private ?User $user;
+    private User $user;
 
     public function __construct(User $user)
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -355,9 +355,9 @@ class User extends Authenticatable implements HasApiTokensContract
 
     public function sendConfirmEmailAndCreatePasswordNotification()
     {
-        $this->user->set_password_token = Str::random(60);
-        $this->user->save();
+        $this->set_password_token = Str::random(60);
+        $this->save();
 
-        Mail::to($this->user->email)->send(new ConfirmEmailAndCreatePasswordMail($this->user, tenant('id')));
+        Mail::to($this->email)->send(new ConfirmEmailAndCreatePasswordMail($this, tenant('id')));
     }
 }


### PR DESCRIPTION
### O que?

Ajuste instancia de e-mail e usuário.

### Por quê?

Usuário incorreto estava recebendo o e-mail de criar usuário.

### Como?

Ajustado parâmetros corretos para função.

