### PR TITLE
feat(usuário): adicionado filtro para buscar por permissão - VLT-156

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -246,7 +246,8 @@ class User extends Authenticatable implements HasApiTokensContract
             ->filterSearch($args)
             ->filterIgnores($args)
             ->filterPosition($args)
-            ->filterTeam($args);
+            ->filterTeam($args)
+            ->filterRoles($args);
     }
 
     public function scopeFilterSearch(Builder $query, array $args)
@@ -345,6 +346,20 @@ class User extends Authenticatable implements HasApiTokensContract
         $query->when(isset($args['filter']) && isset($args['filter']['ignoreIds']), function ($query) use ($args) {
             $query->whereNotIn('users.id', $args['filter']['ignoreIds']);
         });
+    }
+
+    public function scopeFilterRoles(Builder $query, array $args)
+    {
+        $query->when(
+            isset($args['filter']) &&
+            isset($args['filter']['rolesIds']) &&
+            !empty($args['filter']['rolesIds']),
+            function ($query) use ($args) {
+                $query->whereHas('roles', function ($query) use ($args) {
+                    $query->whereIn('id', $args['filter']['rolesIds']);
+                });
+            }
+        );
     }
 
     public function saveLastUserChange()

--- a/graphql/user/UserSearchInput.graphql
+++ b/graphql/user/UserSearchInput.graphql
@@ -10,6 +10,9 @@ input UserSearchInput {
     "Filter by team ids"
     teamsIds: [Int]
 
+    "Filter by role ids"
+    rolesIds: [Int]
+
     "Ignore ids selected"
     ignoreIds: [Int]
 }


### PR DESCRIPTION
### O que?

O guia inicial do sistema não estava listando corretamente os usuários do sistema por permissão, principalmente para o guia que considera o total de jogadores.

### Por quê?

Mostrava o número incorreto de jogadores registrados.

### Como?

Adicionado opção no filtro para listar jogadores de acordo com a permissão.

