### PR TITLE
fix(ambiente): adicionado --force para ambiente de produção executar seeders iniciais

### DIFF
--- a/app/Jobs/RunTenantMigrations.php
+++ b/app/Jobs/RunTenantMigrations.php
@@ -47,7 +47,7 @@ class RunTenantMigrations implements ShouldQueue
 
             tenancy()->initialize($this->tenantId);
 
-            Artisan::call('tenants:seed', ['--tenants' => $this->tenantId]);
+            Artisan::call('tenants:seed', ['--tenants' => $this->tenantId, '--force' => true]);
 
             $user = new User();
             $user->name = $this->name;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "zoren-software/volei-club",
     "type": "project",
     "description": "API for VoleiClub project",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "keywords": ["framework", "laravel"],
     "license": "MIT",
     "require": {


### PR DESCRIPTION
### O que?

Adicionado parâmetro para ambiente de produção

### Por quê?

Para rodar as seeders no ambiente de produção.

### Como?

Adicionado como parâmetro ao comando já existente no processo

### Verificações
- [x] Lembrete: Ajustar o `composer.json` com a versão.

