### PR TITLE
fix(laravel spetie): removendo permissões antigas e reaplicando nova migration

### DIFF
--- a/database/migrations/tenant/base/2024_05_22_234548_create_permission_tables.php
+++ b/database/migrations/tenant/base/2024_05_22_234548_create_permission_tables.php
@@ -11,6 +11,8 @@ return new class extends Migration
      */
     public function up(): void
     {
+        $this->downgradeVersion();
+
         $teams = config('permission.teams');
         $tableNames = config('permission.table_names');
         $columnNames = config('permission.column_names');
@@ -116,6 +118,21 @@ return new class extends Migration
         app('cache')
             ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
             ->forget(config('permission.cache.key'));
+    }
+
+    public function downgradeVersion()
+    {
+        $tableNames = config('permission.table_names');
+
+        if (empty($tableNames)) {
+            throw new \ConfigPermissionLoadedDrop();
+        }
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
     }
 
     /**


### PR DESCRIPTION
### O que?

Refazendo migrations de permissões

### Por quê?

Necessário para atualização das migrations

### Verificações
- [x] Lembrete: Ajustar o `composer.json` com a versão.

