### PR TITLE
fix(usuário): feito correção para relacionamento e mudanças nos atributos de roles - VLT-170

### DIFF
--- a/app/GraphQL/Validators/Mutation/UserEditValidator.php
+++ b/app/GraphQL/Validators/Mutation/UserEditValidator.php
@@ -24,7 +24,7 @@ final class UserEditValidator extends Validator
             'password' => [
                 'sometimes',
                 'min:6' => function (): bool {
-                    return ! empty($this->arg('password')) && $this->arg('password') !== '';
+                    return !empty($this->arg('password')) && $this->arg('password') !== '';
                 },
                 new OwnsPassword($this->arg('id')),
             ],

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Spatie\Permission\Models\Role as SpatieRole;
 
@@ -69,8 +70,10 @@ class Role extends SpatieRole
         });
     }
 
-    public function getNameAttribute($value)
+    protected function name(): Attribute
     {
-        return trans('RoleRegister.' . $value);
+        return Attribute::make(
+            get: fn ($value) => trans('RoleRegister.' . $value)
+        );
     }
 }


### PR DESCRIPTION
### O que?

Ajustado relacionamento de `rolesCustom` que na aplicação é feito de maneira diferente.

### Por quê?

Para remover o erro em tela que na edição dos usuários não estava trazendo as permissões dos usuários que foram feitas na etapa de cadastro. Ficando com o processo errado.

### Como?

Ajustado relacionamento com o model correto e atualizado função com a versão atual do pacote do Laravel Spetie.


### Verificações
- [ ] Lembrete: Ajustar o `composer.json` com a versão.

