### PR TITLE
feat(tenant): adicionando atalho dev resetar senhas e criar tenant

### DIFF
--- a/app/Console/Commands/AdicionaTenantDev.php
+++ b/app/Console/Commands/AdicionaTenantDev.php
@@ -2,8 +2,6 @@
 
 namespace App\Console\Commands;
 
-use Tenancy\Affects\Migrates\Database\Events\ConfigureMigrations;
-
 class AdicionaTenantDev extends CommandDev
 {
     /**
@@ -41,7 +39,8 @@ class AdicionaTenantDev extends CommandDev
 
         foreach ($tenants as $tenant) {
             if (\App\Models\Tenant::find($tenant)) {
-                $this->error("Tenant {$tenant} already exists!");    
+                $this->error("Tenant {$tenant} already exists!");
+
                 continue;
             }
 

--- a/app/Console/Commands/AdicionaTenantDev.php
+++ b/app/Console/Commands/AdicionaTenantDev.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Tenancy\Affects\Migrates\Database\Events\ConfigureMigrations;
+
+class AdicionaTenantDev extends CommandDev
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dev:add-tenant {--tenants=*}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a new tenant to the database Central';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $handle = parent::handle();
+
+        if ($handle === false) {
+            return false;
+        }
+
+        if (!$this->option('tenants')) {
+            $tenants[] = $this->ask('What is the tenant id?');
+        } else {
+            $tenants = $this->option('tenants');
+        }
+
+        foreach ($tenants as $tenant) {
+            if (\App\Models\Tenant::find($tenant)) {
+                $this->error("Tenant {$tenant} already exists!");    
+                continue;
+            }
+
+            $tenant = \App\Models\Tenant::create([
+                'id' => $tenant,
+            ]);
+
+            $this->info("Tenant {$tenant->id} added successfully!");
+
+            $tenant->domains()->create(['domain' => $tenant->id . '.' . env('APP_HOST')]);
+
+            $this->info('Default domain added successfully!');
+            $this->info("{$tenant->id}" . '.' . env('APP_HOST'));
+        }
+    }
+}

--- a/app/Console/Commands/CommandBase.php
+++ b/app/Console/Commands/CommandBase.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class CommandBase extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:name';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    protected $tenant;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->tenant = null;
+    }
+
+    public function formatProgress($tenant)
+    {
+        return "cron - tenant($tenant): PROCESSO $this->nomeProcesso %current%/%max% [%bar%] %percent:3s%% estimated: %estimated:-6s% - current: %elapsed:-3s% \n";
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        //
+    }
+
+    /**
+     * @param mixed $nomeComando
+     * @param mixed $mensagem
+     *
+     * @return void
+     */
+    protected function infoComando($nomeComando, $mensagem): void
+    {
+        if (env('APP_ENV') == 'test') {
+            return;
+        }
+        $this->info('cron - ' . $mensagem . ': ' . $nomeComando);
+    }
+
+    /**
+     * @param mixed $nomeComando
+     * @param mixed $tenant
+     * @param mixed $mensagem
+     *
+     * @return void
+     */
+    protected function processoComando($nomeComando, $tenant, $mensagem): void
+    {
+        if (env('APP_ENV') == 'test') {
+            return;
+        }
+        $this->info('cron - tenant(' . $tenant . '): ' . $mensagem . ' PROCESSO ' . $nomeComando);
+    }
+
+    /**
+     * @param mixed $nomeComando
+     * @param mixed $tenant
+     * @param mixed $mensagem
+     *
+     * @return void
+     */
+    protected function processoComandoCancelado($nomeComando, $tenant, $mensagem): void
+    {
+        if (env('APP_ENV') == 'test') {
+            return;
+        }
+        $this->warn('cron - tenant(' . $tenant . '): ' . $mensagem . ' PROCESSO ' . $nomeComando);
+    }
+
+    /**
+     * @param mixed $nomeComando
+     * @param mixed $tenant
+     * @param mixed $seeder
+     *
+     * @return void
+     */
+    protected function execSeederComando($nomeComando, $tenant, $seeder): void
+    {
+        if (env('APP_ENV') == 'test') {
+            return;
+        }
+        $this->info('cron - tenant(' . $tenant . '): seeder: ' . $seeder . ' PROCESSO ' . $nomeComando);
+    }
+}

--- a/app/Console/Commands/CommandBase.php
+++ b/app/Console/Commands/CommandBase.php
@@ -45,10 +45,8 @@ class CommandBase extends Command
     }
 
     /**
-     * @param mixed $nomeComando
-     * @param mixed $mensagem
-     *
-     * @return void
+     * @param  mixed  $nomeComando
+     * @param  mixed  $mensagem
      */
     protected function infoComando($nomeComando, $mensagem): void
     {
@@ -59,11 +57,9 @@ class CommandBase extends Command
     }
 
     /**
-     * @param mixed $nomeComando
-     * @param mixed $tenant
-     * @param mixed $mensagem
-     *
-     * @return void
+     * @param  mixed  $nomeComando
+     * @param  mixed  $tenant
+     * @param  mixed  $mensagem
      */
     protected function processoComando($nomeComando, $tenant, $mensagem): void
     {
@@ -74,11 +70,9 @@ class CommandBase extends Command
     }
 
     /**
-     * @param mixed $nomeComando
-     * @param mixed $tenant
-     * @param mixed $mensagem
-     *
-     * @return void
+     * @param  mixed  $nomeComando
+     * @param  mixed  $tenant
+     * @param  mixed  $mensagem
      */
     protected function processoComandoCancelado($nomeComando, $tenant, $mensagem): void
     {
@@ -89,11 +83,9 @@ class CommandBase extends Command
     }
 
     /**
-     * @param mixed $nomeComando
-     * @param mixed $tenant
-     * @param mixed $seeder
-     *
-     * @return void
+     * @param  mixed  $nomeComando
+     * @param  mixed  $tenant
+     * @param  mixed  $seeder
      */
     protected function execSeederComando($nomeComando, $tenant, $seeder): void
     {

--- a/app/Console/Commands/CommandDev.php
+++ b/app/Console/Commands/CommandDev.php
@@ -32,11 +32,13 @@ class CommandDev extends CommandBase
     {
         if (env('APP_ENV') == 'production') {
             $this->error('It is not possible to run this command in the production environment');
+
             return false;
         }
 
         if (!(env('APP_DEBUG')) || env('APP_ENV') == 'staging') {
             $this->error('It is not possible to run this command in this environment');
+
             return false;
         }
     }

--- a/app/Console/Commands/CommandDev.php
+++ b/app/Console/Commands/CommandDev.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+class CommandDev extends CommandBase
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dev:new_command';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Description command base';
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        if (env('APP_ENV') == 'production') {
+            $this->error('It is not possible to run this command in the production environment');
+            return false;
+        }
+
+        if (!(env('APP_DEBUG')) || env('APP_ENV') == 'staging') {
+            $this->error('It is not possible to run this command in this environment');
+            return false;
+        }
+    }
+}

--- a/app/Console/Commands/ResetPasswordDev.php
+++ b/app/Console/Commands/ResetPasswordDev.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Models\Tenant;
+use Hash;
+
+class ResetPasswordDev extends CommandDev
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dev:reset-password {--secret=*} {--tenants=*}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Reset the password for all users';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $handle = parent::handle();
+
+        if ($handle === false) {
+            return false;
+        }
+
+        if (!$this->option('secret')) {
+            $secret = $this->ask('What is the new password?');
+        } else {
+            $secret = $this->option('secret')[0];
+        }
+
+        $tenants = $this->option('tenants') == [] 
+            ? Tenant::pluck('id')->toArray()
+            : $this->option('tenants');
+
+        foreach ($tenants as $tenant) {
+            tenancy()->initialize($tenant);
+
+            $this->processoComando('update_passwords', $tenant, 'INICIO');
+
+            try {
+                $total = User::count();
+                $total = $total > 0 ? $total : 1;
+                $total = ceil($total / 100);
+                $bar = $this->output->createProgressBar($total);
+                $bar->start();
+
+                User::chunk(100, function ($users) use ($secret, $bar) {
+                    foreach ($users as $user) {
+                        $user->password = Hash::make($secret);
+                        $user->save();
+                    }
+                    $bar->advance();
+                });
+                $this->processoComando('update_passwords', $tenant, 'FIM');
+            } catch (\Throwable $error) {
+                $this->processoComando('update_passwords', $tenant, 'ERRO');
+                throw $error;
+            }
+        }
+    }
+}

--- a/app/Console/Commands/ResetPasswordDev.php
+++ b/app/Console/Commands/ResetPasswordDev.php
@@ -2,8 +2,8 @@
 
 namespace App\Console\Commands;
 
-use App\Models\User;
 use App\Models\Tenant;
+use App\Models\User;
 use Hash;
 
 class ResetPasswordDev extends CommandDev
@@ -41,7 +41,7 @@ class ResetPasswordDev extends CommandDev
             $secret = $this->option('secret')[0];
         }
 
-        $tenants = $this->option('tenants') == [] 
+        $tenants = $this->option('tenants') == []
             ? Tenant::pluck('id')->toArray()
             : $this->option('tenants');
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -126,7 +126,6 @@ class User extends Authenticatable implements HasApiTokensContract
             ->logOnlyDirty()
             ->dontLogIfAttributesChangedOnly(
                 [
-                    'password',
                     'remember_token',
                     'token',
                     'token_sessao',


### PR DESCRIPTION
### Por quê?

Facilitar processo de manutenção e desenvolvimento

### Como?

Criado dois comandos:
* Atualizar senha (apenas para ambiente de desenvolvimento)
* Criar Tenant

### Capturas de tela

![image](https://github.com/user-attachments/assets/ca1e914d-6251-484e-b8a2-7d2812b743e2)

### Verificações
- [ ] Lembrete: Ajustar o `composer.json` com a versão.

