### PR TITLE
feat(time): adicionando categorias aos times CRUD e relacionamento com time - VT-3

### DIFF
--- a/app/GraphQL/Mutations/NotificationSettingMutation.php
+++ b/app/GraphQL/Mutations/NotificationSettingMutation.php
@@ -2,8 +2,8 @@
 
 namespace App\GraphQL\Mutations;
 
-use App\Models\User;
 use App\Models\NotificationSetting;
+use App\Models\User;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 final class NotificationSettingMutation
@@ -25,12 +25,12 @@ final class NotificationSettingMutation
         $args['user_id'] = $user->id;
 
         $notificationSetting = NotificationSetting::findOrFail($args['id']);
-        
+
         $notificationSetting->fill($args);
 
         $notificationSetting->save();
         $notificationSetting->refresh();
-        
+
         return $notificationSetting;
     }
 }

--- a/app/GraphQL/Mutations/UserMutation.php
+++ b/app/GraphQL/Mutations/UserMutation.php
@@ -51,7 +51,8 @@ final class UserMutation
 
         $this->user->touch();
 
-        return $this->user;
+        // Recarrega o usuário com todos os campos necessários
+        return $this->user->fresh();
     }
 
     /**

--- a/app/GraphQL/Queries/ConfirmationTrainingQuery.php
+++ b/app/GraphQL/Queries/ConfirmationTrainingQuery.php
@@ -8,7 +8,6 @@ use App\Models\Training;
 class ConfirmationTrainingQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/FundamentalQuery.php
+++ b/app/GraphQL/Queries/FundamentalQuery.php
@@ -7,7 +7,6 @@ use App\Models\Fundamental;
 class FundamentalQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/LanguageQuery.php
+++ b/app/GraphQL/Queries/LanguageQuery.php
@@ -7,7 +7,6 @@ use App\Models\Language;
 class LanguageQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/MeQuery.php
+++ b/app/GraphQL/Queries/MeQuery.php
@@ -7,7 +7,6 @@ use App\Models\User;
 class MeQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/NotificationQuery.php
+++ b/app/GraphQL/Queries/NotificationQuery.php
@@ -7,7 +7,6 @@ use App\Models\Notification;
 class NotificationQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/PositionQuery.php
+++ b/app/GraphQL/Queries/PositionQuery.php
@@ -7,7 +7,6 @@ use App\Models\Position;
 class PositionQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/RoleQuery.php
+++ b/app/GraphQL/Queries/RoleQuery.php
@@ -7,7 +7,6 @@ use App\Models\Role;
 class RoleQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/SpecificFundamentalQuery.php
+++ b/app/GraphQL/Queries/SpecificFundamentalQuery.php
@@ -7,7 +7,6 @@ use App\Models\SpecificFundamental;
 class SpecificFundamentalQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/TeamCategoryQuery.php
+++ b/app/GraphQL/Queries/TeamCategoryQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\TeamCategory;
+
+class TeamCategoryQuery
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function list($_, array $args)
+    {
+        $teamCategory = new TeamCategory();
+
+        return $teamCategory->list($args);
+    }
+}

--- a/app/GraphQL/Queries/TeamLevelQuery.php
+++ b/app/GraphQL/Queries/TeamLevelQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Models\TeamLevel;
+
+class TeamLevelQuery
+{
+    /**
+     * @param  null  $_
+     * @param  array{}  $args
+     */
+    public function list($_, array $args)
+    {
+        $teamLevel = new TeamLevel();
+
+        return $teamLevel->list($args);
+    }
+}

--- a/app/GraphQL/Queries/TeamQuery.php
+++ b/app/GraphQL/Queries/TeamQuery.php
@@ -7,7 +7,6 @@ use App\Models\Team;
 class TeamQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/TrainingQuery.php
+++ b/app/GraphQL/Queries/TrainingQuery.php
@@ -7,7 +7,6 @@ use App\Models\Training;
 class TrainingQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Queries/UserQuery.php
+++ b/app/GraphQL/Queries/UserQuery.php
@@ -7,7 +7,6 @@ use App\Models\User;
 class UserQuery
 {
     /**
-     *
      * @param  null  $_
      * @param  array{}  $args
      */

--- a/app/GraphQL/Validators/Mutation/NotificationSettingEditValidator.php
+++ b/app/GraphQL/Validators/Mutation/NotificationSettingEditValidator.php
@@ -2,7 +2,6 @@
 
 namespace App\GraphQL\Validators\Mutation;
 
-use App\Models\Training;
 use Nuwave\Lighthouse\Validation\Validator;
 
 class NotificationSettingEditValidator extends Validator
@@ -38,8 +37,6 @@ class NotificationSettingEditValidator extends Validator
 
     /**
      * TODO - Add custom messages for validation rules.
-     * 
-     * @return array
      */
     public function messages(): array
     {

--- a/app/Models/NotificationSetting.php
+++ b/app/Models/NotificationSetting.php
@@ -74,36 +74,25 @@ class NotificationSetting extends Model
                 ->orderBy('created_at', 'desc');
     }
 
-    /**
-     * @param  Builder  $query
-     * @param  array $args
-     */
     public function scopeFilterIsActive(Builder $query, array $args)
     {
-        return 
+        return
             $query->when(isset($args['filter']) && isset($args['filter']['is_active']), function ($query) use ($args) {
                 $query->where('is_active', $args['filter']['is_active']);
             });
     }
 
-    /**
-     * @param  Builder  $query
-     * @param  array $args
-     */
     public function scopeFilterViaEmail(Builder $query, array $args)
     {
-        return 
+        return
             $query->when(isset($args['filter']) && isset($args['filter']['via_email']), function ($query) use ($args) {
                 $query->where('via_email', $args['filter']['via_email']);
             });
     }
-    /**
-     * @param  Builder  $query
-     * @param  array $args
-     */
+
     public function scopeFilterViaSystem(Builder $query, array $args)
     {
-        return 
+        return
             $query->when(isset($args['filter']) && isset($args['filter']['via_system']), function ($query) use ($args) {
                 $query->where('via_system', $args['filter']['via_system']);
             });

--- a/app/Models/PositionsUsers.php
+++ b/app/Models/PositionsUsers.php
@@ -10,6 +10,8 @@ class PositionsUsers extends Pivot
 {
     use LogsActivity;
 
+    protected $table = 'positions_users';
+
     /**
      * Indicates if the IDs are auto-incrementing.
      *

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -68,12 +68,12 @@ class Team extends Model
             ->dontSubmitEmptyLogs();
     }
 
-    public function category()
+    public function teamCategory()
     {
         return $this->belongsTo(TeamCategory::class, 'team_category_id');
     }
 
-    public function level()
+    public function teamLevel()
     {
         return $this->belongsTo(TeamLevel::class, 'team_level_id');
     }
@@ -82,8 +82,8 @@ class Team extends Model
     {
         return $this
             ->with([
-                'category:id,name,updated_at',
-                'level:id,name,updated_at',
+                'teamCategory:id,name,updated_at',
+                'teamLevel:id,name,updated_at',
             ])
             ->filterSearch($args)
             ->filterIgnores($args)

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -18,6 +18,8 @@ class Team extends Model
     protected $fillable = [
         'name',
         'user_id',
+        'team_category_id',
+        'team_level_id',
     ];
 
     public function user()
@@ -71,9 +73,18 @@ class Team extends Model
         return $this->belongsTo(TeamCategory::class, 'team_category_id');
     }
 
+    public function level()
+    {
+        return $this->belongsTo(TeamLevel::class, 'team_level_id');
+    }
+
     public function list(array $args)
     {
         return $this
+            ->with([
+                'category',
+                'level',
+            ])
             ->filterSearch($args)
             ->filterIgnores($args)
             ->filterPosition($args)

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -82,8 +82,8 @@ class Team extends Model
     {
         return $this
             ->with([
-                'category',
-                'level',
+                'category:id,name,updated_at',
+                'level:id,name,updated_at',
             ])
             ->filterSearch($args)
             ->filterIgnores($args)

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -66,6 +66,11 @@ class Team extends Model
             ->dontSubmitEmptyLogs();
     }
 
+    public function category()
+    {
+        return $this->belongsTo(TeamCategory::class, 'team_category_id');
+    }
+
     public function list(array $args)
     {
         return $this

--- a/app/Models/TeamCategory.php
+++ b/app/Models/TeamCategory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Spatie\Activitylog\LogOptions;
+
+class TeamCategory extends Model
+{
+    use SoftDeletes;
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'min_age',
+        'max_age',
+    ];
+
+    public function teams()
+    {
+        return $this->hasMany(Team::class);
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->useLogName($this->table)
+            ->logOnly(['*'])
+            ->logOnlyDirty()
+            ->dontLogIfAttributesChangedOnly(
+                [
+                    'updated_at',
+                    'created_at',
+                    'deleted_at',
+                ]
+            )
+            ->dontSubmitEmptyLogs();
+    }
+}

--- a/app/Models/TeamCategory.php
+++ b/app/Models/TeamCategory.php
@@ -49,7 +49,7 @@ class TeamCategory extends Model
 
     public function scopeFilterSearch($query, array $args)
     {
-        $query->when(isset($args['search']), function ($query) use ($args) {
+        return $query->when(isset($args['search']), function ($query) use ($args) {
             $query->where('team_categories.name', 'like', '%' . $args['search'] . '%');
         });
     }

--- a/app/Models/TeamCategory.php
+++ b/app/Models/TeamCategory.php
@@ -2,15 +2,15 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Spatie\Activitylog\LogOptions;
 
 class TeamCategory extends Model
 {
-    use SoftDeletes;
     use HasFactory;
+    use SoftDeletes;
 
     protected $fillable = [
         'name',

--- a/app/Models/TeamCategory.php
+++ b/app/Models/TeamCategory.php
@@ -52,6 +52,7 @@ class TeamCategory extends Model
         return $query->when(isset($args['search']), function ($query) use ($args) {
             $query->where('team_categories.name', 'like', '%' . $args['search'] . '%');
         });
+        return $query;
     }
 
     public function scopeFilterIgnores($query, array $args)

--- a/app/Models/TeamCategory.php
+++ b/app/Models/TeamCategory.php
@@ -39,4 +39,25 @@ class TeamCategory extends Model
             )
             ->dontSubmitEmptyLogs();
     }
+
+    public function list(array $args)
+    {
+        return $this
+            ->filterSearch($args)
+            ->filterIgnores($args);
+    }
+
+    public function scopeFilterSearch($query, array $args)
+    {
+        $query->when(isset($args['search']), function ($query) use ($args) {
+            $query->where('team_categories.name', 'like', '%' . $args['search'] . '%');
+        });
+    }
+
+    public function scopeFilterIgnores($query, array $args)
+    {
+        $query->when(isset($args['ignore']), function ($query) use ($args) {
+            $query->whereNotIn('team_categories.id', $args['ignore']);
+        });
+    }
 }

--- a/app/Models/TeamLevel.php
+++ b/app/Models/TeamLevel.php
@@ -4,9 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 class TeamLevel extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'name',
         'description',

--- a/app/Models/TeamLevel.php
+++ b/app/Models/TeamLevel.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class TeamLevel extends Model
@@ -14,5 +15,27 @@ class TeamLevel extends Model
     public function teams()
     {
         return $this->hasMany(Team::class);
+    }
+
+    public function list(array $args)
+    {
+        return $this
+            ->filterSearch($args)
+            ->filterIgnores($args);
+    }
+
+    public function scopeFilterSearch(Builder $query, array $args)
+    {
+        $query->when(isset($args['search']), function ($query) use ($args) {
+            $query->where('team_levels.name', 'like', '%' . $args['search'] . '%');
+        });
+
+    }
+
+    public function scopeFilterIgnores(Builder $query, array $args)
+    {
+        $query->when(isset($args['ignore']), function ($query) use ($args) {
+            $query->whereNotIn('team_levels.id', $args['ignore']);
+        });
     }
 }

--- a/app/Models/TeamLevel.php
+++ b/app/Models/TeamLevel.php
@@ -3,8 +3,9 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
 class TeamLevel extends Model
 {
     use HasFactory;

--- a/app/Models/TeamLevel.php
+++ b/app/Models/TeamLevel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TeamLevel extends Model
+{
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+
+    public function teams()
+    {
+        return $this->hasMany(Team::class);
+    }
+}

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -2,6 +2,9 @@
 
 namespace App\Models;
 
+use App\Mail\Training\CancellationTrainingMail;
+use App\Mail\Training\ConfirmationTrainingMail;
+use App\Mail\Training\TrainingMail;
 use App\Notifications\Training\CancelTrainingNotification;
 use App\Notifications\Training\ConfirmationTrainingNotification;
 use App\Notifications\Training\TrainingNotification;
@@ -13,9 +16,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
-use App\Mail\Training\ConfirmationTrainingMail;
-use App\Mail\Training\TrainingMail;
-use App\Mail\Training\CancellationTrainingMail;
 
 class Training extends Model
 {
@@ -136,7 +136,7 @@ class Training extends Model
                 if ($technician->canReceiveNotification('training_created', 'system')) {
                     $technician->notify(new ConfirmationTrainingNotification($this, null));
                 }
-    
+
                 if ($technician->canReceiveNotification('training_created', 'email')) {
                     \Mail::to($technician->email)
                         ->send(new ConfirmationTrainingMail($this, $technician));

--- a/app/Notifications/Training/CancelTrainingNotification.php
+++ b/app/Notifications/Training/CancelTrainingNotification.php
@@ -2,7 +2,6 @@
 
 namespace App\Notifications\Training;
 
-use App\Mail\Training\CancellationTrainingMail;
 use App\Models\User;
 
 class CancelTrainingNotification extends Notification

--- a/app/Notifications/Training/ConfirmationTrainingNotification.php
+++ b/app/Notifications/Training/ConfirmationTrainingNotification.php
@@ -2,7 +2,6 @@
 
 namespace App\Notifications\Training;
 
-use App\Mail\Training\ConfirmationNotificationTrainingMail;
 use App\Models\User;
 
 class ConfirmationTrainingNotification extends Notification

--- a/app/Notifications/Training/Notification.php
+++ b/app/Notifications/Training/Notification.php
@@ -4,8 +4,6 @@ namespace App\Notifications\Training;
 
 use App\Models\ConfirmationTraining;
 use App\Models\Training;
-use App\Models\TrainingConfig;
-use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification as IlluminateNotification;
@@ -35,7 +33,7 @@ class Notification extends IlluminateNotification implements ShouldQueue
 
     /**
      * Get the notification's delivery channels.
-     * 
+     *
      * NOTE - Todas as notificações Training agora são apenas via sistema (database).
      *
      * @param  mixed  $notifiable

--- a/app/Notifications/Training/TrainingNotification.php
+++ b/app/Notifications/Training/TrainingNotification.php
@@ -2,8 +2,6 @@
 
 namespace App\Notifications\Training;
 
-use App\Mail\Training\TrainingMail;
-
 class TrainingNotification extends Notification
 {
     /**

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -2,9 +2,9 @@
 
 namespace App\Observers;
 
-use App\Models\User;
-use App\Models\NotificationType;
 use App\Models\NotificationSetting;
+use App\Models\NotificationType;
+use App\Models\User;
 
 class UserObserver
 {
@@ -17,9 +17,8 @@ class UserObserver
 
     /**
      * NOTE Create notification settings default for the user
-     * 
-     * @param User $user
-     * 
+     *
+     *
      * @return [type]
      */
     public function created(User $user)

--- a/app/Policies/TeamCategoryPolicy.php
+++ b/app/Policies/TeamCategoryPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TeamCategoryPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * View a team instance.
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('view-team-categories');
+    }
+}

--- a/app/Policies/TeamLevelPolicy.php
+++ b/app/Policies/TeamLevelPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TeamLevelPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * View a team instance.
+     */
+    public function view(User $user): bool
+    {
+        return $user->hasPermissionTo('view-team-levels');
+    }
+}

--- a/database/factories/TeamCategoryFactory.php
+++ b/database/factories/TeamCategoryFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TeamCategory>
+ */
+class TeamCategoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name() . ' TEAM CATEGORY',
+            'description' => $this->faker->text(),
+            'min_age' => $this->faker->numberBetween(12, 19),
+            'max_age' => $this->faker->numberBetween(35, 100),
+        ];
+    }
+
+    public function setAttributes(array $attributes)
+    {
+        return $this->state(function (array $attributesOriginal) use ($attributes) {
+            return array_merge($attributesOriginal, $attributes);
+        });
+    }
+}

--- a/database/factories/TeamCategoryFactory.php
+++ b/database/factories/TeamCategoryFactory.php
@@ -2,8 +2,6 @@
 
 namespace Database\Factories;
 
-use App\Models\Team;
-use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -2,8 +2,8 @@
 
 namespace Database\Factories;
 
-use App\Models\User;
 use App\Models\Team;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -38,4 +38,11 @@ class TeamFactory extends Factory
             );
         });
     }
+
+    public function setAttributes(array $attributes)
+    {
+        return $this->state(function (array $attributesOriginal) use ($attributes) {
+            return array_merge($attributesOriginal, $attributes);
+        });
+    }
 }

--- a/database/factories/TeamLevelFactory.php
+++ b/database/factories/TeamLevelFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TeamLevel>
+ */
+class TeamLevelFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name() . ' TEAM LEVEL',
+            'description' => $this->faker->text(),
+        ];
+    }
+
+    public function setAttributes(array $attributes)
+    {
+        return $this->state(function (array $attributesOriginal) use ($attributes) {
+            return array_merge($attributesOriginal, $attributes);
+        });
+    }
+}

--- a/database/factories/TeamLevelFactory.php
+++ b/database/factories/TeamLevelFactory.php
@@ -2,8 +2,6 @@
 
 namespace Database\Factories;
 
-use App\Models\Team;
-use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,9 +2,9 @@
 
 namespace Database\Factories;
 
-use App\Models\User;
-use App\Models\NotificationType;
 use App\Models\NotificationSetting;
+use App\Models\NotificationType;
+use App\Models\User;
 use App\Models\UserInformation;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
@@ -50,7 +50,7 @@ class UserFactory extends Factory
             $types = NotificationType::where('is_active', true)->get();
 
             foreach ($types as $type) {
-                if($type->id != null) {
+                if ($type->id != null) {
                     NotificationSetting::updateOrCreate(
                         [
                             'user_id' => $user->id,
@@ -62,8 +62,7 @@ class UserFactory extends Factory
                             'is_active' => true,
                         ]
                     );
-                }
-                else {
+                } else {
                     dd($type);
                 }
             }

--- a/database/migrations/tenant/base/2025_02_12_000001_create_team_categories_table.php
+++ b/database/migrations/tenant/base/2025_02_12_000001_create_team_categories_table.php
@@ -13,15 +13,16 @@ return new class() extends Migration
      */
     public function up()
     {
-        if (!Schema::hasTable('teams')) {
-            Schema::create('teams', function (Blueprint $table) {
+        if (!Schema::hasTable('team_categories')) {
+            Schema::create('team_categories', function (Blueprint $table) {
                 $table->id();
-                $table->unsignedBigInteger('user_id');
-                $table->unsignedBigInteger('team_category_id')
-                    ->nullable();
-                $table->unsignedBigInteger('team_level_id')
-                    ->nullable();
                 $table->string('name');
+                $table->string('description')
+                    ->nullable();
+                $table->integer('min_age')
+                    ->nullable();
+                $table->integer('max_age')
+                    ->nullable();
                 $table->timestamps();
                 $table->softDeletes();
             });
@@ -35,6 +36,6 @@ return new class() extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('teams');
+        Schema::dropIfExists('team_categories');
     }
 };

--- a/database/migrations/tenant/base/2025_02_12_000001_create_team_levels_table.php
+++ b/database/migrations/tenant/base/2025_02_12_000001_create_team_levels_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('team_levels')) {
+            Schema::create('team_levels', function (Blueprint $table) {
+                $table->id();
+                $table->string('name');
+                $table->string('description')
+                    ->nullable();
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('team_levels');
+    }
+};

--- a/database/migrations/tenant/base/2025_02_12_000002_m1_05_add_foreign_keys_to_teams_table.php
+++ b/database/migrations/tenant/base/2025_02_12_000002_m1_05_add_foreign_keys_to_teams_table.php
@@ -23,7 +23,7 @@ return new class() extends Migration
                         ->onDelete('cascade');
                 }
                 if (
-                    !hasForeignKeyExist('teams', 'teams_team_category_id_foreign') && 
+                    !hasForeignKeyExist('teams', 'teams_team_category_id_foreign') &&
                     Schema::hasColumn('teams', 'team_category_id')
                 ) {
                     $table->foreign('team_category_id')

--- a/database/migrations/tenant/base/2025_02_12_000002_m1_05_add_foreign_keys_to_teams_table.php
+++ b/database/migrations/tenant/base/2025_02_12_000002_m1_05_add_foreign_keys_to_teams_table.php
@@ -22,6 +22,23 @@ return new class() extends Migration
                         ->on('users')
                         ->onDelete('cascade');
                 }
+                if (
+                    !hasForeignKeyExist('teams', 'teams_team_category_id_foreign') && 
+                    Schema::hasColumn('teams', 'team_category_id')
+                ) {
+                    $table->foreign('team_category_id')
+                        ->references('id')
+                        ->on('team_categories')
+                        ->nullOnDelete();
+                }
+                if (!hasForeignKeyExist('teams', 'teams_team_level_id_foreign') &&
+                    Schema::hasColumn('teams', 'team_level_id')
+                ) {
+                    $table->foreign('team_level_id')
+                        ->references('id')
+                        ->on('team_levels')
+                        ->nullOnDelete();
+                }
             });
         }
 

--- a/database/migrations/tenant/releases/2025_04_13_211300_exec_notification_settings_seeder.php
+++ b/database/migrations/tenant/releases/2025_04_13_211300_exec_notification_settings_seeder.php
@@ -1,15 +1,14 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
 use Database\Seeders\Tenants\NotificationSettingsSeeder;
 use Database\Seeders\Tenants\NotificationTypesSeeder;
+use Illuminate\Database\Migrations\Migration;
 
 return new class() extends Migration
 {
-
     /**
      * NOTE - Apagavel após release
-     * 
+     *
      * @return [type]
      */
     public function up()

--- a/database/migrations/tenant/releases/2025_05_06_000001_add_column_to_teams_table.php
+++ b/database/migrations/tenant/releases/2025_05_06_000001_add_column_to_teams_table.php
@@ -8,7 +8,7 @@ return new class() extends Migration
 {
     /**
      * NOTE - Apagável na próxima versão
-     * 
+     *
      * @return [type]
      */
     public function up()

--- a/database/migrations/tenant/releases/2025_05_06_000001_add_column_to_teams_table.php
+++ b/database/migrations/tenant/releases/2025_05_06_000001_add_column_to_teams_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * NOTE - Apagável na próxima versão
+     * 
+     * @return [type]
+     */
+    public function up()
+    {
+        if (Schema::hasTable('teams')) {
+            Schema::table('teams', function (Blueprint $table) {
+
+                if (!Schema::hasColumn('teams', 'team_category_id')) {
+                    $table->unsignedBigInteger('team_category_id')
+                        ->nullable()
+                        ->after('user_id');
+                }
+
+                if (!Schema::hasColumn('teams', 'team_level_id')) {
+                    $table->unsignedBigInteger('team_level_id')
+                        ->nullable()
+                        ->after('team_category_id');
+                }
+            });
+        }
+    }
+
+    public function down()
+    {
+        if (Schema::hasTable('teams')) {
+            Schema::table('teams', function (Blueprint $table) {
+                if (Schema::hasColumn('teams', 'team_category_id')) {
+                    $table->dropColumn('team_category_id');
+                }
+
+                if (Schema::hasColumn('teams', 'team_level_id')) {
+                    $table->dropColumn('team_level_id');
+                }
+            });
+        }
+    }
+};

--- a/database/migrations/tenant/releases/2025_05_06_000002_add_foreign_keys_to_teams_table.php
+++ b/database/migrations/tenant/releases/2025_05_06_000002_add_foreign_keys_to_teams_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * NOTE - Apagável na próxima versão
+     * 
+     * @return [type]
+     */
+    public function up()
+    {
+        if (Schema::hasTable('teams')) {
+            Schema::table('teams', function (Blueprint $table) {
+                if (!hasForeignKeyExist('teams', 'teams_team_level_id_foreign') &&
+                    Schema::hasColumn('teams', 'team_level_id')
+                ) {
+                    $table->foreign('team_level_id')
+                        ->references('id')
+                        ->on('team_levels');
+                }
+            });
+        }
+    }
+
+    public function down()
+    {
+        if (Schema::hasTable('teams')) {
+            Schema::table('teams', function (Blueprint $table) {
+                if (hasForeignKeyExist('teams', 'teams_team_level_id_foreign') &&
+                    Schema::hasColumn('teams', 'team_level_id')
+                ) {
+                    $table->dropForeign('teams_team_level_id_foreign');
+                }
+            });
+        }
+    }
+};

--- a/database/migrations/tenant/releases/2025_05_06_000002_add_foreign_keys_to_teams_table.php
+++ b/database/migrations/tenant/releases/2025_05_06_000002_add_foreign_keys_to_teams_table.php
@@ -8,7 +8,7 @@ return new class() extends Migration
 {
     /**
      * NOTE - Apagável na próxima versão
-     * 
+     *
      * @return [type]
      */
     public function up()

--- a/database/migrations/tenant/releases/2025_05_06_000003_add_foreign_keys_to_teams_table.php
+++ b/database/migrations/tenant/releases/2025_05_06_000003_add_foreign_keys_to_teams_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * NOTE - Apagável na próxima versão
+     * 
+     * @return [type]
+     */
+    public function up()
+    {
+        if (Schema::hasTable('teams')) {
+            Schema::table('teams', function (Blueprint $table) {
+                if (
+                    !hasForeignKeyExist('teams', 'teams_team_category_id_foreign') && 
+                    Schema::hasColumn('teams', 'team_category_id')
+                ) {
+                    $table->foreign('team_category_id')
+                        ->references('id')
+                        ->on('team_categories')
+                        ->nullOnDelete();
+                }
+            });
+        }
+    }
+
+    public function down()
+    {
+        if (Schema::hasTable('teams')) {
+            Schema::table('teams', function (Blueprint $table) {
+                if (hasForeignKeyExist('teams', 'teams_team_category_id_foreign') &&
+                    Schema::hasColumn('teams', 'team_category_id')
+                ) {
+                    $table->dropForeign('teams_team_category_id_foreign');
+                }
+            });
+        }
+    }
+};

--- a/database/migrations/tenant/releases/2025_05_06_000003_add_foreign_keys_to_teams_table.php
+++ b/database/migrations/tenant/releases/2025_05_06_000003_add_foreign_keys_to_teams_table.php
@@ -8,7 +8,7 @@ return new class() extends Migration
 {
     /**
      * NOTE - Apagável na próxima versão
-     * 
+     *
      * @return [type]
      */
     public function up()
@@ -16,7 +16,7 @@ return new class() extends Migration
         if (Schema::hasTable('teams')) {
             Schema::table('teams', function (Blueprint $table) {
                 if (
-                    !hasForeignKeyExist('teams', 'teams_team_category_id_foreign') && 
+                    !hasForeignKeyExist('teams', 'teams_team_category_id_foreign') &&
                     Schema::hasColumn('teams', 'team_category_id')
                 ) {
                     $table->foreign('team_category_id')

--- a/database/seeders/tenants/DatabaseTenantSeeder.php
+++ b/database/seeders/tenants/DatabaseTenantSeeder.php
@@ -22,6 +22,8 @@ class DatabaseTenantSeeder extends Seeder
             PermissionTableSeeder::class,
             FundamentalTableSeeder::class,
             PositionTableSeeder::class,
+            TeamCategoryTableSeeder::class,
+            TeamLevelTableSeeder::class,
         ]);
     }
 }

--- a/database/seeders/tenants/NotificationSettingsSeeder.php
+++ b/database/seeders/tenants/NotificationSettingsSeeder.php
@@ -11,7 +11,7 @@ class NotificationSettingsSeeder extends Seeder
 {
     /**
      * Run the database seeds.
-     * 
+     *
      * NOTE - Seeder para gerar as configurações de notificação para os usuários padrão.
      * NOTE - Apagavel após release
      */

--- a/database/seeders/tenants/PermissionTableSeeder.php
+++ b/database/seeders/tenants/PermissionTableSeeder.php
@@ -98,11 +98,17 @@ class PermissionTableSeeder extends Seeder
         $teamLevels[] = Permission::updateOrCreate(['id' => 23], ['name' => 'view-team-levels']);
 
         /**
+         * Permissões de Time Categories
+         */
+        $teamCategories[] = Permission::updateOrCreate(['id' => 24], ['name' => 'view-team-categories']);
+
+        /**
          * Relacionando Permissões
          */
         $this->sync($admin, $user);
         $this->sync($admin, $team);
         $this->sync($admin, $teamLevels);
+        $this->sync($admin, $teamCategories);
         $this->sync($admin, $role);
         $this->sync($admin, $fundamental);
         $this->sync($admin, $position);
@@ -115,6 +121,7 @@ class PermissionTableSeeder extends Seeder
         $this->sync($technician, $user);
         $this->sync($technician, $team);
         $this->sync($technician, $teamLevels);
+        $this->sync($technician, $teamCategories);
         $this->sync($technician, $role);
         $this->sync($technician, $fundamental);
         $this->sync($technician, $position);
@@ -127,6 +134,7 @@ class PermissionTableSeeder extends Seeder
         $this->sync($player, $user);
         $this->sync($player, $team);
         $this->sync($player, $teamLevels);
+        $this->sync($player, $teamCategories);
         $this->sync($player, $role);
         $this->sync($player, $fundamental);
         $this->sync($player, $position);

--- a/database/seeders/tenants/PermissionTableSeeder.php
+++ b/database/seeders/tenants/PermissionTableSeeder.php
@@ -93,10 +93,16 @@ class PermissionTableSeeder extends Seeder
         $confirmationTraining[] = Permission::updateOrCreate(['id' => 22], ['name' => 'view-confirmation-training']);
 
         /**
+         * Permissões Time Levels
+         */
+        $teamLevels[] = Permission::updateOrCreate(['id' => 23], ['name' => 'view-team-levels']);
+
+        /**
          * Relacionando Permissões
          */
         $this->sync($admin, $user);
         $this->sync($admin, $team);
+        $this->sync($admin, $teamLevels);
         $this->sync($admin, $role);
         $this->sync($admin, $fundamental);
         $this->sync($admin, $position);
@@ -108,6 +114,7 @@ class PermissionTableSeeder extends Seeder
 
         $this->sync($technician, $user);
         $this->sync($technician, $team);
+        $this->sync($technician, $teamLevels);
         $this->sync($technician, $role);
         $this->sync($technician, $fundamental);
         $this->sync($technician, $position);
@@ -119,6 +126,7 @@ class PermissionTableSeeder extends Seeder
 
         $this->sync($player, $user);
         $this->sync($player, $team);
+        $this->sync($player, $teamLevels);
         $this->sync($player, $role);
         $this->sync($player, $fundamental);
         $this->sync($player, $position);

--- a/database/seeders/tenants/TeamCategoryTableSeeder.php
+++ b/database/seeders/tenants/TeamCategoryTableSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders\Tenants;
+
+use App\Models\TeamCategory;
+use Illuminate\Database\Seeder;
+
+class TeamCategoryTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $teamCategories = [
+            ['name' => 'Sub-13', 'description' => 'Atletas até 13 anos', 'min_age' => 0, 'max_age' => 13],
+            ['name' => 'Sub-15', 'description' => 'Atletas de 14 a 15 anos', 'min_age' => 14, 'max_age' => 15],
+            ['name' => 'Sub-17', 'description' => 'Atletas de 16 a 17 anos', 'min_age' => 16, 'max_age' => 17],
+            ['name' => 'Sub-19', 'description' => 'Atletas de 18 a 19 anos', 'min_age' => 18, 'max_age' => 19],
+            ['name' => 'Adulto', 'description' => 'A partir de 20 anos', 'min_age' => 20, 'max_age' => null],
+            ['name' => 'Master', 'description' => 'Veteranos acima de 35 anos', 'min_age' => 35, 'max_age' => null],
+        ];
+
+        foreach ($teamCategories as $categoria) {
+            TeamCategory::updateOrCreate(
+                ['name' => $categoria['name']],
+                $categoria
+            );
+        }
+    }
+}

--- a/database/seeders/tenants/TeamLevelTableSeeder.php
+++ b/database/seeders/tenants/TeamLevelTableSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders\Tenants;
+
+use App\Models\TeamLevel;
+use Illuminate\Database\Seeder;
+
+class TeamLevelTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $teamLevels = [
+            ['name' => 'Bronze', 'description' => 'Nível inicial de competição'],
+            ['name' => 'Prata', 'description' => 'Nível intermediário de competição'],
+            ['name' => 'Ouro', 'description' => 'Nível avançado de competição'],
+            ['name' => 'Elite', 'description' => 'Nível de alta performance ou seleções'],
+        ];
+
+        foreach ($teamLevels as $level) {
+            TeamLevel::updateOrCreate(
+                ['name' => $level['name']],
+                $level
+            );
+        }
+    }
+}

--- a/database/seeders/tenants/UserTableSeeder.php
+++ b/database/seeders/tenants/UserTableSeeder.php
@@ -2,9 +2,9 @@
 
 namespace Database\Seeders\Tenants;
 
-use App\Models\User;
 use App\Models\NotificationSetting;
 use App\Models\NotificationType;
+use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -4,6 +4,7 @@
 #import user/*.graphql
 #import team/*.graphql
 #import team-levels/*.graphql
+#import team-categories/*.graphql
 #import training/*.graphql
 #import training-config/*.graphql
 #import sanctum/*.graphql

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -3,6 +3,7 @@
 #import language/*.graphql
 #import user/*.graphql
 #import team/*.graphql
+#import team-levels/*.graphql
 #import training/*.graphql
 #import training-config/*.graphql
 #import sanctum/*.graphql

--- a/graphql/team-categories/TeamCategorySearchInput.graphql
+++ b/graphql/team-categories/TeamCategorySearchInput.graphql
@@ -1,0 +1,9 @@
+"TeamSearchType"
+input TeamCategorySearchInput {
+
+    "String to search for in teams name"
+    search: String
+
+    "Ignore ids selected"
+    ignoreIds: [Int]
+}

--- a/graphql/team-categories/TeamCategoryType.graphql
+++ b/graphql/team-categories/TeamCategoryType.graphql
@@ -1,0 +1,23 @@
+"Teams "
+type TeamCategory {
+    "Unique primary key."
+    id: ID!
+
+    "Unique name."
+    name: String!
+
+    "Team level description."
+    description: String @rename(attribute: "description")
+
+    "Min Age."
+    minAge: Int @rename(attribute: "min_age")
+
+    "Max Age."
+    maxAge: Int @rename(attribute: "max_age")
+
+    "Date created. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
+    createdAt: DateTime! @rename(attribute: "created_at")
+    
+    "Date updated. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
+    updatedAt: DateTime! @rename(attribute: "updated_at")
+}

--- a/graphql/team-categories/TeamLevelQuery.graphql
+++ b/graphql/team-categories/TeamLevelQuery.graphql
@@ -1,0 +1,18 @@
+extend type Query @guard {
+    
+    "Find a single team by an identifying attribute"
+    teamCategory(
+        id: ID!
+        @eq
+    ): TeamCategory
+        @can(ability: "view", resolved: true)
+        @find
+
+    "List multiple teams."
+    teamCategories(
+        "Specific filter search teams."
+        filter: TeamCategorySearchInput
+    ): [TeamCategory!]!
+        @paginate(defaultCount: 10, maxCount: 100, builder: "App\\GraphQL\\Queries\\TeamCategoryQuery@list")
+        @can(ability: "view", resolved: true)
+}

--- a/graphql/team-levels/TeamLevelQuery.graphql
+++ b/graphql/team-levels/TeamLevelQuery.graphql
@@ -1,0 +1,18 @@
+extend type Query @guard {
+    
+    "Find a single team by an identifying attribute"
+    teamLevel(
+        id: ID!
+        @eq
+    ): TeamLevel
+        @can(ability: "view", resolved: true)
+        @find
+
+    "List multiple teams."
+    teamLevels(
+        "Specific filter search teams."
+        filter: TeamLevelSearchInput
+    ): [TeamLevel!]!
+        @paginate(defaultCount: 10, maxCount: 100, builder: "App\\GraphQL\\Queries\\TeamLevelQuery@list")
+        @can(ability: "view", resolved: true)
+}

--- a/graphql/team-levels/TeamLevelSearchInput.graphql
+++ b/graphql/team-levels/TeamLevelSearchInput.graphql
@@ -1,0 +1,9 @@
+"TeamSearchType"
+input TeamLevelSearchInput {
+
+    "String to search for in teams name"
+    search: String
+
+    "Ignore ids selected"
+    ignoreIds: [Int]
+}

--- a/graphql/team-levels/TeamLevelType.graphql
+++ b/graphql/team-levels/TeamLevelType.graphql
@@ -1,0 +1,17 @@
+"Teams "
+type TeamLevel {
+    "Unique primary key."
+    id: ID!
+
+    "Unique name."
+    name: String!
+
+    "Team level description."
+    description: String @rename(attribute: "description")
+
+    "Date created. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
+    createdAt: DateTime! @rename(attribute: "created_at")
+    
+    "Date updated. A datetime string with format `Y-m-d H:i:s`, e.g. `2018-05-23 13:43:32`."
+    updatedAt: DateTime! @rename(attribute: "updated_at")
+}

--- a/graphql/team/TeamMutation.graphql
+++ b/graphql/team/TeamMutation.graphql
@@ -3,6 +3,8 @@ extend type Mutation @guard {
     teamCreate(
         name: String!
         playerId: [ID] @rename(attribute: "player_id")
+        teamCategoryId: ID @rename(attribute: "team_category_id")
+        teamLevelId: ID @rename(attribute: "team_level_id")
     ): Team
         @field(resolver: "TeamMutation@make") 
         @validator
@@ -12,6 +14,8 @@ extend type Mutation @guard {
         id: ID!
         name: String!
         playerId: [ID] @rename(attribute: "player_id")
+        teamCategoryId: ID @rename(attribute: "team_category_id")
+        teamLevelId: ID @rename(attribute: "team_level_id")
     ): Team
         @field(resolver: "TeamMutation@make") 
         @validator

--- a/graphql/team/TeamType.graphql
+++ b/graphql/team/TeamType.graphql
@@ -8,7 +8,19 @@ type Team {
 
     "UserId editing the team."
     userId: Int @rename(attribute: "user_id")
-    
+
+    "teamCategoryId editing the team."
+    teamCategoryId: Int @rename(attribute: "team_category_id")
+
+    "Team category."
+    teamCategory: TeamCategory @belongsTo
+
+    "teamLevelId editing the team."
+    teamLevelId: Int @rename(attribute: "team_level_id")
+
+    "Team level."
+    teamLevel: TeamLevel @belongsTo
+
     "User editing the team."
     user: User @belongsTo
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -47,6 +47,9 @@
         <testsuite name="Team">
             <file>./tests/Feature/GraphQL/TeamTest.php</file>
         </testsuite>
+        <testsuite name="TeamLevel">
+            <file>./tests/Feature/GraphQL/TeamLevelTest.php</file>
+        </testsuite>
         <testsuite name="TrainingConfig">
             <file>./tests/Feature/GraphQL/TrainingConfigTest.php</file>
         </testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -50,6 +50,9 @@
         <testsuite name="TeamLevel">
             <file>./tests/Feature/GraphQL/TeamLevelTest.php</file>
         </testsuite>
+        <testsuite name="TeamCategory">
+            <file>./tests/Feature/GraphQL/TeamCategoryTest.php</file>
+        </testsuite>
         <testsuite name="TrainingConfig">
             <file>./tests/Feature/GraphQL/TrainingConfigTest.php</file>
         </testsuite>

--- a/tests/Feature/Database/Tenants/DataInitials/NotificationTypesSeederTest.php
+++ b/tests/Feature/Database/Tenants/DataInitials/NotificationTypesSeederTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Database\Tenants\DataInitials;
 
 use App\Models\NotificationType;
 use App\Models\User;
+use App\Models\UserInformation;
 use Database\Seeders\Tenants\UserTableSeeder;
 use Illuminate\Support\Facades\DB;
 
@@ -16,6 +17,7 @@ class NotificationTypesSeederTest extends DataAbstract
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
 
         User::truncate();
+        UserInformation::truncate();
 
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 

--- a/tests/Feature/Database/Tenants/DataInitials/TeamCategorySeederTest.php
+++ b/tests/Feature/Database/Tenants/DataInitials/TeamCategorySeederTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Database\Tenants\DataInitials;
+
+use App\Models\TeamCategory;
+use Database\Seeders\Tenants\TeamCategoryTableSeeder;
+use Illuminate\Support\Facades\DB;
+
+class TeamCategorySeederTest extends DataAbstract
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        TeamCategory::truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+        $this->seed([
+            TeamCategoryTableSeeder::class,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function teamCategoriesAreSeeded(): void
+    {
+        $expectedCategories = [
+            'Sub-13',
+            'Sub-15',
+            'Sub-17',
+            'Sub-19',
+            'Adulto',
+            'Master',
+        ];
+
+        foreach ($expectedCategories as $category) {
+            $this->assertDatabaseHas('team_categories', ['name' => $category]);
+        }
+
+        $this->assertDatabaseCount('team_categories', count($expectedCategories));
+    }
+}

--- a/tests/Feature/Database/Tenants/DataInitials/TeamLevelSeederTest.php
+++ b/tests/Feature/Database/Tenants/DataInitials/TeamLevelSeederTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Database\Tenants\DataInitials;
+
+use App\Models\TeamLevel;
+use Database\Seeders\Tenants\TeamLevelTableSeeder;
+use Illuminate\Support\Facades\DB;
+
+class TeamLevelSeederTest extends DataAbstract
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        TeamLevel::truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+        $this->seed([
+            TeamLevelTableSeeder::class,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function teamLevelsAreSeeded(): void
+    {
+        $expectedLevels = [
+            'Bronze',
+            'Prata',
+            'Ouro',
+            'Elite',
+        ];
+
+        foreach ($expectedLevels as $level) {
+            $this->assertDatabaseHas('team_levels', ['name' => $level]);
+        }
+
+        $this->assertDatabaseCount('team_levels', count($expectedLevels));
+    }
+}

--- a/tests/Feature/Database/Tenants/TeamCategoriesTest.php
+++ b/tests/Feature/Database/Tenants/TeamCategoriesTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature\Database\Tenants;
+
+class TeamCategoriesTest extends TenantBase
+{
+    protected $table = 'team_categories';
+
+    public static $fieldTypes = [
+        'id' => ['type' => 'bigint', 'unsigned' => true],
+        'name' => ['type' => 'varchar', 'length' => 255, 'collation' => 'utf8mb4_unicode_ci'],
+        'description' => ['type' => 'varchar', 'length' => 255, 'collation' => 'utf8mb4_unicode_ci', 'nullable' => true],
+        'min_age' => ['type' => 'int', 'nullable' => true],
+        'max_age' => ['type' => 'int', 'nullable' => true],
+        'created_at' => ['type' => 'timestamp', 'nullable' => true],
+        'updated_at' => ['type' => 'timestamp', 'nullable' => true],
+        'deleted_at' => ['type' => 'timestamp', 'nullable' => true],
+    ];
+
+    public static $primaryKey = ['id'];
+
+    public static $autoIncrements = ['id'];
+
+    public static $foreignKeys = [];
+
+    public static $uniqueKeys = [];
+}

--- a/tests/Feature/Database/Tenants/TeamLevelsTest.php
+++ b/tests/Feature/Database/Tenants/TeamLevelsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature\Database\Tenants;
+
+class TeamLevelsTest extends TenantBase
+{
+    protected $table = 'team_levels';
+
+    public static $fieldTypes = [
+        'id' => ['type' => 'bigint', 'unsigned' => true],
+        'name' => ['type' => 'varchar', 'length' => 255, 'collation' => 'utf8mb4_unicode_ci'],
+        'description' => ['type' => 'varchar', 'length' => 255, 'collation' => 'utf8mb4_unicode_ci', 'nullable' => true],
+        'created_at' => ['type' => 'timestamp', 'nullable' => true],
+        'updated_at' => ['type' => 'timestamp', 'nullable' => true],
+    ];
+
+    public static $primaryKey = ['id'];
+
+    public static $autoIncrements = ['id'];
+
+    public static $foreignKeys = [];
+
+    public static $uniqueKeys = [];
+}

--- a/tests/Feature/Database/Tenants/TeamsTest.php
+++ b/tests/Feature/Database/Tenants/TeamsTest.php
@@ -9,6 +9,8 @@ class TeamsTest extends TenantBase
     public static $fieldTypes = [
         'id' => ['type' => 'bigint', 'unsigned' => true],
         'user_id' => ['type' => 'bigint', 'unsigned' => true],
+        'team_category_id' => ['type' => 'bigint', 'unsigned' => true, 'nullable' => true],
+        'team_level_id' => ['type' => 'bigint', 'unsigned' => true, 'nullable' => true],
         'name' => ['type' => 'varchar', 'length' => 255, 'collation' => 'utf8mb4_unicode_ci'],
         'created_at' => ['type' => 'timestamp', 'nullable' => true],
         'updated_at' => ['type' => 'timestamp', 'nullable' => true],
@@ -21,6 +23,8 @@ class TeamsTest extends TenantBase
 
     public static $foreignKeys = [
         'teams_user_id_foreign',
+        'teams_team_category_id_foreign',
+        'teams_team_level_id_foreign',
     ]; // Define as chaves estrangeiras
 
     public static $uniqueKeys = []; // Nenhuma chave única

--- a/tests/Feature/Database/Tenants/TotalTablesTenantTest.php
+++ b/tests/Feature/Database/Tenants/TotalTablesTenantTest.php
@@ -25,7 +25,7 @@ class TotalTablesTenantTest extends TestCase
         $totalTables = count($tables);
 
         $this->assertEquals(
-            29,
+            31,
             $totalTables,
             PHP_EOL . PHP_EOL .
             'O número total de tabelas está incorreto.' . PHP_EOL .

--- a/tests/Feature/GraphQL/ConfirmationTrainingTest.php
+++ b/tests/Feature/GraphQL/ConfirmationTrainingTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\GraphQL;
 use App\Models\Team;
 use App\Models\Training;
 use Tests\TestCase;
+use Illuminate\Support\Facades\DB;
 
 class ConfirmationTrainingTest extends TestCase
 {
@@ -27,6 +28,31 @@ class ConfirmationTrainingTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->limparAmbiente();
+    }
+
+    public function tearDown(): void
+    {
+        $this->limparAmbiente();
+
+        parent::tearDown();
+    }
+
+    private function limparAmbiente(): void
+    {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+        Team::truncate();
+        Training::truncate();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+    }
 
     private function setPermissions(bool $hasPermission)
     {

--- a/tests/Feature/GraphQL/ConfirmationTrainingTest.php
+++ b/tests/Feature/GraphQL/ConfirmationTrainingTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature\GraphQL;
 
 use App\Models\Team;
 use App\Models\Training;
-use Tests\TestCase;
 use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
 
 class ConfirmationTrainingTest extends TestCase
 {
@@ -29,7 +29,6 @@ class ConfirmationTrainingTest extends TestCase
         'updatedAt',
     ];
 
-    
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -3,11 +3,10 @@
 namespace Tests\Feature\GraphQL;
 
 use App\Models\Fundamental;
-use Faker\Factory as Faker;
-use Tests\TestCase;
 use Database\Seeders\Tenants\FundamentalTableSeeder;
+use Faker\Factory as Faker;
 use Illuminate\Support\Facades\DB;
-
+use Tests\TestCase;
 
 class FundamentalTest extends TestCase
 {
@@ -36,11 +35,11 @@ class FundamentalTest extends TestCase
     public function tearDown(): void
     {
         $this->limparAmbiente();
-        
+
         parent::tearDown();
     }
 
-    private function limparAmbiente() : void
+    private function limparAmbiente(): void
     {
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         Fundamental::truncate();

--- a/tests/Feature/GraphQL/FundamentalTest.php
+++ b/tests/Feature/GraphQL/FundamentalTest.php
@@ -5,6 +5,9 @@ namespace Tests\Feature\GraphQL;
 use App\Models\Fundamental;
 use Faker\Factory as Faker;
 use Tests\TestCase;
+use Database\Seeders\Tenants\FundamentalTableSeeder;
+use Illuminate\Support\Facades\DB;
+
 
 class FundamentalTest extends TestCase
 {
@@ -23,6 +26,30 @@ class FundamentalTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->limparAmbiente();
+    }
+
+    public function tearDown(): void
+    {
+        $this->limparAmbiente();
+        
+        parent::tearDown();
+    }
+
+    private function limparAmbiente() : void
+    {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        Fundamental::truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+        $this->seed([
+            FundamentalTableSeeder::class,
+        ]);
+    }
 
     private function setPermissions(bool $hasPermission)
     {

--- a/tests/Feature/GraphQL/NotificationSettingTest.php
+++ b/tests/Feature/GraphQL/NotificationSettingTest.php
@@ -66,15 +66,15 @@ class NotificationSettingTest extends TestCase
      * @author Maicon Cerutti
      *
      * @test
-     * 
+     *
      * @dataProvider notificationSettingActiveEmailAndSystemEditSuccess
      * @dataProvider notificationSettingDesactiveEmailAndSystemEditSuccess
      * @dataProvider notificationSettingActiveEmailEditSuccess
      * @dataProvider notificationSettingActiveSystemEditSuccess
      * @dataProvider notificationSettingRequiredParametersEditError
-     * 
+     *
      * TODO - Falta criar os cenários de erro do request e mensagens traduzidas
-     * 
+     *
      * @return void
      */
     public function notificationSettingEdit(
@@ -83,15 +83,14 @@ class NotificationSettingTest extends TestCase
         $typeMessageError,
         $expectedMessage,
         $expected,
-    )
-    {
-        $user = User::factory()->create(); 
+    ) {
+        $user = User::factory()->create();
 
         $this->be($user);
 
         if ($parameters['notificationTypeId'] === false) {
             unset($parameters['notificationTypeId']);
-        } elseif ($parameters['notificationTypeId']  === 'notExists') {
+        } elseif ($parameters['notificationTypeId'] === 'notExists') {
             $parameters['notificationTypeId'] = NotificationSetting::max('notification_type_id') + 1;
         } elseif ($parameters['notificationTypeId'] === 'test') {
             $parameters['notificationTypeId'] = 'test';
@@ -103,11 +102,11 @@ class NotificationSettingTest extends TestCase
 
         if ($parameters['id'] === false) {
             unset($parameters['id']);
-        } elseif($parameters['id'] === 'test') {
+        } elseif ($parameters['id'] === 'test') {
 
-        } elseif($parameters['id'] === 'notExists') {
+        } elseif ($parameters['id'] === 'notExists') {
             $parameters['id'] = NotificationSetting::max('id') + 1;
-        } else{
+        } else {
             $parameters['id'] = $user->notificationSettings
                 ->when(isset($parameters['notificationTypeId']), function ($query) use ($parameters) {
                     return $query->where('notification_type_id', $parameters['notificationTypeId']);
@@ -132,7 +131,8 @@ class NotificationSettingTest extends TestCase
             ->assertStatus(200);
     }
 
-    public static function notificationSettingActiveEmailAndSystemEditSuccess() {
+    public static function notificationSettingActiveEmailAndSystemEditSuccess()
+    {
         return [
             'notification setting edit, active email and system notification type account confirmation' => [
                 'data' => [
@@ -194,7 +194,8 @@ class NotificationSettingTest extends TestCase
         ];
     }
 
-    public static function notificationSettingActiveEmailEditSuccess() {
+    public static function notificationSettingActiveEmailEditSuccess()
+    {
         return [
             'notification setting edit, active email notification type account confirmation' => [
                 'data' => [
@@ -256,7 +257,8 @@ class NotificationSettingTest extends TestCase
         ];
     }
 
-    public static function notificationSettingActiveSystemEditSuccess() {
+    public static function notificationSettingActiveSystemEditSuccess()
+    {
         return [
             'notification setting edit, active system notification type account confirmation' => [
                 'data' => [
@@ -318,7 +320,8 @@ class NotificationSettingTest extends TestCase
         ];
     }
 
-    public static function notificationSettingDesactiveEmailAndSystemEditSuccess() {
+    public static function notificationSettingDesactiveEmailAndSystemEditSuccess()
+    {
         return [
             'notification setting edit, desactive email and system notification type account confirmation' => [
                 'data' => [

--- a/tests/Feature/GraphQL/NotificationSettingTest.php
+++ b/tests/Feature/GraphQL/NotificationSettingTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GraphQL;
 
 use App\Models\NotificationSetting;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class NotificationSettingTest extends TestCase
@@ -24,6 +25,28 @@ class NotificationSettingTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->limparAmbiente();
+    }
+
+    public function tearDown(): void
+    {
+        $this->limparAmbiente();
+
+        parent::tearDown();
+    }
+
+    private function limparAmbiente(): void
+    {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        
+        NotificationSetting::truncate();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+    }
 
     /**
      * Listagem de configurações de notificação

--- a/tests/Feature/GraphQL/NotificationSettingTest.php
+++ b/tests/Feature/GraphQL/NotificationSettingTest.php
@@ -42,7 +42,7 @@ class NotificationSettingTest extends TestCase
     private function limparAmbiente(): void
     {
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
-        
+
         NotificationSetting::truncate();
 
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');

--- a/tests/Feature/GraphQL/NotificationTest.php
+++ b/tests/Feature/GraphQL/NotificationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GraphQL;
 
 use App\Models\Notification;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class NotificationTest extends TestCase
@@ -24,6 +25,28 @@ class NotificationTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->limparAmbiente();
+    }
+
+    public function tearDown(): void
+    {
+        $this->limparAmbiente();
+
+        parent::tearDown();
+    }
+
+    private function limparAmbiente(): void
+    {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        
+        Notification::truncate();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+    }
 
     /**
      * A basic feature test example.

--- a/tests/Feature/GraphQL/NotificationTest.php
+++ b/tests/Feature/GraphQL/NotificationTest.php
@@ -42,7 +42,7 @@ class NotificationTest extends TestCase
     private function limparAmbiente(): void
     {
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
-        
+
         Notification::truncate();
 
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -3,10 +3,11 @@
 namespace Tests\Feature\GraphQL;
 
 use App\Models\Position;
+use Database\Seeders\Tenants\PositionTableSeeder;
 use Faker\Factory as Faker;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
-use Database\Seeders\Tenants\PositionTableSeeder;
+
 class PositionTest extends TestCase
 {
     protected $graphql = true;

--- a/tests/Feature/GraphQL/PositionTest.php
+++ b/tests/Feature/GraphQL/PositionTest.php
@@ -6,7 +6,7 @@ use App\Models\Position;
 use Faker\Factory as Faker;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
-
+use Database\Seeders\Tenants\PositionTableSeeder;
 class PositionTest extends TestCase
 {
     protected $graphql = true;
@@ -45,6 +45,10 @@ class PositionTest extends TestCase
         Position::truncate();
 
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+        $this->seed([
+            PositionTableSeeder::class,
+        ]);
     }
 
     private function setPermissions(bool $hasPermission)

--- a/tests/Feature/GraphQL/SanctumTest.php
+++ b/tests/Feature/GraphQL/SanctumTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Feature\GraphQL;
 
 use App\Models\User;
+use App\Models\UserInformation;
+use Database\Seeders\Tenants\UserTableSeeder;
 use Faker\Factory as Faker;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class SanctumTest extends TestCase
@@ -22,6 +25,34 @@ class SanctumTest extends TestCase
      * @var bool
      */
     protected $otherUser = true;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->limparAmbiente();
+    }
+
+    public function tearDown(): void
+    {
+        $this->limparAmbiente();
+        parent::tearDown();
+    }
+
+    private function limparAmbiente(): void
+    {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+        // Só remove os outros usuários, se necessário
+        UserInformation::where('user_id', '!=', $this->user?->id)->forceDelete();
+        User::where('id', '!=', $this->user?->id)->forceDelete();
+
+        // Não remova os tokens nem o usuário autenticado
+        // DB::table('personal_access_tokens')->truncate();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+        // Não precisa do seeder se o TestCase já cria o user
+    }
 
     /**
      * Teste da rota de login.

--- a/tests/Feature/GraphQL/SanctumTest.php
+++ b/tests/Feature/GraphQL/SanctumTest.php
@@ -46,12 +46,11 @@ class SanctumTest extends TestCase
         UserInformation::where('user_id', '!=', $this->user?->id)->forceDelete();
         User::where('id', '!=', $this->user?->id)->forceDelete();
 
-        // Não remova os tokens nem o usuário autenticado
-        // DB::table('personal_access_tokens')->truncate();
-
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
-        // Não precisa do seeder se o TestCase já cria o user
+        $this->seed([
+            UserTableSeeder::class,
+        ]);
     }
 
     /**

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -4,7 +4,12 @@ namespace Tests\Feature\GraphQL;
 
 use App\Models\Fundamental;
 use App\Models\SpecificFundamental;
+use Database\Seeders\Tenants\UserTableSeeder;
+use Database\Seeders\Tenants\FundamentalTableSeeder;
+
+
 use Faker\Factory as Faker;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class SpecificFundamentalTest extends TestCase
@@ -24,6 +29,34 @@ class SpecificFundamentalTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->limparAmbiente();
+    }
+
+    public function tearDown(): void
+    {
+        $this->limparAmbiente();
+
+        parent::tearDown();
+    }
+
+    private function limparAmbiente(): void
+    {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+        SpecificFundamental::truncate();
+        Fundamental::truncate();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+        $this->seed([
+            UserTableSeeder::class,
+            FundamentalTableSeeder::class,
+        ]);
+    }
 
     private function setPermissions(bool $hasPermission)
     {
@@ -205,6 +238,11 @@ class SpecificFundamentalTest extends TestCase
     ) {
         $this->setPermissions($hasPermission);
 
+        if ($parameters['name'] === 'nameExistent') {
+            $specificFundamental = SpecificFundamental::factory()->create();
+            $parameters['name'] = $specificFundamental->name;
+        }
+
         $fundamental = Fundamental::factory()->make();
         $fundamental->save();
 
@@ -285,7 +323,7 @@ class SpecificFundamentalTest extends TestCase
             ],
             'name field is not unique, expected error' => [
                 [
-                    'name' => $nameExistent,
+                    'name' => 'nameExistent',
                     'userId' => $userId,
                 ],
                 'typeMessageError' => 'name',

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -4,10 +4,7 @@ namespace Tests\Feature\GraphQL;
 
 use App\Models\Fundamental;
 use App\Models\SpecificFundamental;
-use Database\Seeders\Tenants\UserTableSeeder;
 use Database\Seeders\Tenants\FundamentalTableSeeder;
-
-
 use Faker\Factory as Faker;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;

--- a/tests/Feature/GraphQL/SpecificFundamentalTest.php
+++ b/tests/Feature/GraphQL/SpecificFundamentalTest.php
@@ -53,7 +53,6 @@ class SpecificFundamentalTest extends TestCase
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
         $this->seed([
-            UserTableSeeder::class,
             FundamentalTableSeeder::class,
         ]);
     }

--- a/tests/Feature/GraphQL/TeamCategoryTest.php
+++ b/tests/Feature/GraphQL/TeamCategoryTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Team;
+use App\Models\TeamCategory;
+use App\Models\TeamLevel;
+use Faker\Factory as Faker;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class TeamCategoryTest extends TestCase
+{
+    protected $graphql = true;
+
+    protected $tenancy = true;
+
+    protected $login = true;
+
+    private $role = 'technician';
+
+    public static $data = [
+        'id',
+        'name',
+        'description',
+        'minAge',
+        'maxAge',
+        'createdAt',
+        'updatedAt',
+    ];
+
+    private function setPermissions(bool $hasPermission)
+    {
+        $this->checkPermission($hasPermission, $this->role, 'view-team-categories');
+    }
+
+    /**
+     * Listagem de todos os times.
+     *
+     * @author Maicon Cerutti
+     *
+     * @test
+     *
+     * @dataProvider listProvider
+     *
+     * @return void
+     */
+    public function teamCategoriesList(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $hasPermission
+    ) {
+        $this->setPermissions($hasPermission);
+
+        $response = $this->graphQL(
+            'teamCategories',
+            [
+                'first' => 10,
+                'page' => 1,
+            ],
+            [
+                'paginatorInfo' => self::$paginatorInfo,
+                'data' => self::$data,
+            ],
+            'query',
+            false
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $hasPermission,
+            $expectedMessage
+        );
+
+        if ($hasPermission) {
+            $response
+                ->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function listProvider()
+    {
+        return [
+            'with permission' => [
+                'typeMessageError' => false,
+                'expectedMessage' => false,
+                'expected' => [
+                    'data' => [
+                        'teamCategories' => [
+                            'paginatorInfo' => self::$paginatorInfo,
+                            'data' => [
+                                '*' => self::$data,
+                            ],
+                        ],
+                    ],
+                ],
+                'hasPermission' => true,
+            ],
+            'without permission' => [
+                'typeMessageError' => 'message',
+                'expectedMessage' => self::$unauthorized,
+                'expected' => [
+                    'errors' => self::$errors,
+                ],
+                'hasPermission' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Listagem de um time
+     *
+     * @author Maicon Cerutti
+     *
+     * @test
+     *
+     * @dataProvider infoProvider
+     *
+     * @return void
+     */
+    public function teamCategoryInfo(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $hasPermission
+    ) {
+        $this->setPermissions($hasPermission);
+
+        $response = $this->graphQL(
+            'teamCategory',
+            [
+                'id' => 1,
+            ],
+            self::$data,
+            'query',
+            false
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $hasPermission,
+            $expectedMessage
+        );
+
+        if ($hasPermission) {
+            $response->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function infoProvider()
+    {
+        return [
+            'with permission' => [
+                'typeMessageError' => false,
+                'expectedMessage' => false,
+                'expected' => [
+                    'data' => [
+                        'teamCategory' => self::$data,
+                    ],
+                ],
+                'hasPermission' => true,
+            ],
+            'without permission' => [
+                'typeMessageError' => 'message',
+                'expectedMessage' => self::$unauthorized,
+                'expected' => [
+                    'errors' => self::$errors,
+                ],
+                'hasPermission' => false,
+            ],
+        ];
+    }
+
+}

--- a/tests/Feature/GraphQL/TeamCategoryTest.php
+++ b/tests/Feature/GraphQL/TeamCategoryTest.php
@@ -2,11 +2,6 @@
 
 namespace Tests\Feature\GraphQL;
 
-use App\Models\Team;
-use App\Models\TeamCategory;
-use App\Models\TeamLevel;
-use Faker\Factory as Faker;
-use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class TeamCategoryTest extends TestCase
@@ -181,5 +176,4 @@ class TeamCategoryTest extends TestCase
             ],
         ];
     }
-
 }

--- a/tests/Feature/GraphQL/TeamLevelTest.php
+++ b/tests/Feature/GraphQL/TeamLevelTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use App\Models\Team;
+use App\Models\TeamCategory;
+use App\Models\TeamLevel;
+use Faker\Factory as Faker;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class TeamLevelTest extends TestCase
+{
+    protected $graphql = true;
+
+    protected $tenancy = true;
+
+    protected $login = true;
+
+    private $role = 'technician';
+
+    public static $data = [
+        'id',
+        'name',
+        'description',
+        'createdAt',
+        'updatedAt',
+    ];
+
+    private function setPermissions(bool $hasPermission)
+    {
+        $this->checkPermission($hasPermission, $this->role, 'view-team-levels');
+    }
+
+    /**
+     * Listagem de todos os times.
+     *
+     * @author Maicon Cerutti
+     *
+     * @test
+     *
+     * @dataProvider listProvider
+     *
+     * @return void
+     */
+    public function teamLevelsList(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $hasPermission
+    ) {
+        $this->setPermissions($hasPermission);
+
+        $response = $this->graphQL(
+            'teamLevels',
+            [
+                'first' => 10,
+                'page' => 1,
+            ],
+            [
+                'paginatorInfo' => self::$paginatorInfo,
+                'data' => self::$data,
+            ],
+            'query',
+            false
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $hasPermission,
+            $expectedMessage
+        );
+
+        if ($hasPermission) {
+            $response
+                ->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function listProvider()
+    {
+        return [
+            'with permission' => [
+                'typeMessageError' => false,
+                'expectedMessage' => false,
+                'expected' => [
+                    'data' => [
+                        'teamLevels' => [
+                            'paginatorInfo' => self::$paginatorInfo,
+                            'data' => [
+                                '*' => self::$data,
+                            ],
+                        ],
+                    ],
+                ],
+                'hasPermission' => true,
+            ],
+            'without permission' => [
+                'typeMessageError' => 'message',
+                'expectedMessage' => self::$unauthorized,
+                'expected' => [
+                    'errors' => self::$errors,
+                ],
+                'hasPermission' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Listagem de um time
+     *
+     * @author Maicon Cerutti
+     *
+     * @test
+     *
+     * @dataProvider infoProvider
+     *
+     * @return void
+     */
+    public function teamLevelInfo(
+        $typeMessageError,
+        $expectedMessage,
+        $expected,
+        bool $hasPermission
+    ) {
+        $this->setPermissions($hasPermission);
+
+        $response = $this->graphQL(
+            'teamLevel',
+            [
+                'id' => 1,
+            ],
+            self::$data,
+            'query',
+            false
+        );
+
+        $this->assertMessageError(
+            $typeMessageError,
+            $response,
+            $hasPermission,
+            $expectedMessage
+        );
+
+        if ($hasPermission) {
+            $response->assertJsonStructure($expected)
+                ->assertStatus(200);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function infoProvider()
+    {
+        return [
+            'with permission' => [
+                'typeMessageError' => false,
+                'expectedMessage' => false,
+                'expected' => [
+                    'data' => [
+                        'teamLevel' => self::$data,
+                    ],
+                ],
+                'hasPermission' => true,
+            ],
+            'without permission' => [
+                'typeMessageError' => 'message',
+                'expectedMessage' => self::$unauthorized,
+                'expected' => [
+                    'errors' => self::$errors,
+                ],
+                'hasPermission' => false,
+            ],
+        ];
+    }
+
+}

--- a/tests/Feature/GraphQL/TeamLevelTest.php
+++ b/tests/Feature/GraphQL/TeamLevelTest.php
@@ -2,11 +2,6 @@
 
 namespace Tests\Feature\GraphQL;
 
-use App\Models\Team;
-use App\Models\TeamCategory;
-use App\Models\TeamLevel;
-use Faker\Factory as Faker;
-use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class TeamLevelTest extends TestCase
@@ -179,5 +174,4 @@ class TeamLevelTest extends TestCase
             ],
         ];
     }
-
 }

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -251,6 +251,20 @@ class TeamTest extends TestCase
     ) {
         $this->setPermissions($hasPermission);
 
+        if (isset($parameters['teamCategoryId'])) {
+            if ($parameters['teamCategoryId'] == true) {
+                $teamCategory = TeamCategory::factory()->create();
+                $parameters['teamCategoryId'] = $teamCategory->id;
+            }
+        }
+
+        if (isset($parameters['teamLevelId'])) {
+            if ($parameters['teamLevelId'] == true) {
+                $teamLevel = TeamLevel::factory()->create();
+                $parameters['teamLevelId'] = $teamLevel->id;
+            }
+        }
+
         if ($parameters['name'] == 'nameExistent') {
             $team = Team::factory()->create();
             $parameters['name'] = $team->name;
@@ -334,6 +348,21 @@ class TeamTest extends TestCase
                 ],
                 'hasPermission' => true,
             ],
+            'create team and relating a team category and team level, success' => [
+                [
+                    'name' => $faker->name,
+                    'teamCategoryId' => true,
+                    'teamLevelId' => true,
+                ],
+                'typeMessageError' => false,
+                'expectedMessage' => false,
+                'expected' => [
+                    'data' => [
+                        'teamCreate' => self::$data,
+                    ],
+                ],
+                'hasPermission' => true,
+            ],
             'name field is not unique, expected error' => [
                 [
                     'name' => 'nameExistent',
@@ -402,6 +431,20 @@ class TeamTest extends TestCase
         $team->save();
 
         $parameters['id'] = $team->id;
+
+        if (isset($parameters['teamCategoryId'])) {
+            if ($parameters['teamCategoryId'] == true) {
+                $teamCategory = TeamCategory::factory()->create();
+                $parameters['teamCategoryId'] = $teamCategory->id;
+            }
+        }
+
+        if (isset($parameters['teamLevelId'])) {
+            if ($parameters['teamLevelId'] == true) {
+                $teamLevel = TeamLevel::factory()->create();
+                $parameters['teamLevelId'] = $teamLevel->id;
+            }
+        }
 
         if ($expectedMessage == 'TeamEdit.name_unique') {
             $parameters['name'] = $teamExist->name;
@@ -472,6 +515,21 @@ class TeamTest extends TestCase
                 [
                     'name' => $faker->name . self::$teamText,
                     'playerId' => [1, 2, 3],
+                ],
+                'typeMessageError' => false,
+                'expectedMessage' => false,
+                'expected' => [
+                    'data' => [
+                        'teamEdit' => self::$data,
+                    ],
+                ],
+                'hasPermission' => true,
+            ],
+            'edit team and relating a team category and team level, success' => [
+                [
+                    'name' => $faker->name,
+                    'teamCategoryId' => true,
+                    'teamLevelId' => true,
                 ],
                 'typeMessageError' => false,
                 'expectedMessage' => false,

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -105,8 +105,6 @@ class TeamTest extends TestCase
             false
         );
 
-        dd($response->json());
-
         $this->assertMessageError(
             $typeMessageError,
             $response,

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GraphQL;
 
 use App\Models\Team;
 use Faker\Factory as Faker;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class TeamTest extends TestCase
@@ -25,6 +26,28 @@ class TeamTest extends TestCase
         'createdAt',
         'updatedAt',
     ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->limparAmbiente();
+    }
+
+    public function tearDown(): void
+    {
+        $this->limparAmbiente();
+
+        parent::tearDown();
+    }
+
+    private function limparAmbiente(): void
+    {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+        Team::truncate();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+    }
 
     private function setPermissions(bool $hasPermission)
     {
@@ -205,6 +228,11 @@ class TeamTest extends TestCase
     ) {
         $this->setPermissions($hasPermission);
 
+        if ($parameters['name'] == 'nameExistent') {
+            $team = Team::factory()->create();
+            $parameters['name'] = $team->name;
+        }
+
         $response = $this->graphQL(
             'teamCreate',
             $parameters,
@@ -285,7 +313,7 @@ class TeamTest extends TestCase
             ],
             'name field is not unique, expected error' => [
                 [
-                    'name' => $nameExistent,
+                    'name' => 'nameExistent',
                     'playerId' => [],
                 ],
                 'typeMessageError' => 'name',

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -25,7 +25,6 @@ class TeamTest extends TestCase
         'id',
         'name',
         'userId',
-        // TODO - Parei aqui fazendo relacionamento para trazer entidades
         'teamCategoryId',
         'teamLevelId',
         'createdAt',

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature\GraphQL;
 
 use App\Models\Team;
+use App\Models\TeamCategory;
+use App\Models\TeamLevel;
 use Faker\Factory as Faker;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
@@ -23,6 +25,9 @@ class TeamTest extends TestCase
         'id',
         'name',
         'userId',
+        // TODO - Parei aqui fazendo relacionamento para trazer entidades
+        'teamCategoryId',
+        'teamLevelId',
         'createdAt',
         'updatedAt',
     ];
@@ -74,7 +79,17 @@ class TeamTest extends TestCase
     ) {
         $this->setPermissions($hasPermission);
 
-        Team::factory()->make()->save();
+        $teamCategory = TeamCategory::where('id', 1)->first();
+
+        $teamLevel = TeamLevel::where('id', 1)->first();
+
+        $team = Team::factory()
+            ->hasPlayers(10)
+            ->setAttributes([
+                'team_category_id' => $teamCategory->id,
+                'team_level_id' => $teamLevel->id,
+            ])
+            ->create();
 
         $response = $this->graphQL(
             'teams',
@@ -89,6 +104,8 @@ class TeamTest extends TestCase
             'query',
             false
         );
+
+        dd($response->json());
 
         $this->assertMessageError(
             $typeMessageError,
@@ -155,8 +172,17 @@ class TeamTest extends TestCase
     ) {
         $this->setPermissions($hasPermission);
 
-        $team = Team::factory()->make();
-        $team->save();
+        $teamCategory = TeamCategory::where('id', 1)->first();
+
+        $teamLevel = TeamLevel::where('id', 1)->first();
+
+        $team = Team::factory()
+            ->hasPlayers(10)
+            ->setAttributes([
+                'team_category_id' => $teamCategory->id,
+                'team_level_id' => $teamLevel->id,
+            ])
+            ->create();
 
         $response = $this->graphQL(
             'team',

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -9,6 +9,8 @@ use App\Models\TeamsUsers;
 use Faker\Factory as Faker;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
+use Database\Seeders\Tenants\TeamCategoryTableSeeder;
+use Database\Seeders\Tenants\TeamLevelTableSeeder;
 
 class TeamTest extends TestCase
 {
@@ -51,8 +53,15 @@ class TeamTest extends TestCase
 
         Team::truncate();
         TeamsUsers::truncate();
+        TeamCategory::truncate();
+        TeamLevel::truncate();
 
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+        $this->seed([
+            TeamCategoryTableSeeder::class,
+            TeamLevelTableSeeder::class,
+        ]);
     }
 
     private function setPermissions(bool $hasPermission)

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -6,11 +6,11 @@ use App\Models\Team;
 use App\Models\TeamCategory;
 use App\Models\TeamLevel;
 use App\Models\TeamsUsers;
+use Database\Seeders\Tenants\TeamCategoryTableSeeder;
+use Database\Seeders\Tenants\TeamLevelTableSeeder;
 use Faker\Factory as Faker;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
-use Database\Seeders\Tenants\TeamCategoryTableSeeder;
-use Database\Seeders\Tenants\TeamLevelTableSeeder;
 
 class TeamTest extends TestCase
 {

--- a/tests/Feature/GraphQL/TeamTest.php
+++ b/tests/Feature/GraphQL/TeamTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\GraphQL;
 use App\Models\Team;
 use App\Models\TeamCategory;
 use App\Models\TeamLevel;
+use App\Models\TeamsUsers;
 use Faker\Factory as Faker;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
@@ -49,6 +50,7 @@ class TeamTest extends TestCase
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
 
         Team::truncate();
+        TeamsUsers::truncate();
 
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
     }
@@ -82,7 +84,7 @@ class TeamTest extends TestCase
 
         $teamLevel = TeamLevel::where('id', 1)->first();
 
-        $team = Team::factory()
+        Team::factory()
             ->hasPlayers(10)
             ->setAttributes([
                 'team_category_id' => $teamCategory->id,

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -7,6 +7,7 @@ use App\Models\TeamsUsers;
 use App\Models\Training;
 use App\Models\User;
 use Faker\Factory as Faker;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class TrainingTest extends TestCase
@@ -52,6 +53,30 @@ class TrainingTest extends TestCase
     {
         $this->checkPermission($hasPermission, $this->role, 'edit-training');
         $this->checkPermission($hasPermission, $this->role, 'view-training');
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->limparAmbiente();
+    }
+
+    public function tearDown(): void
+    {
+        $this->limparAmbiente();
+
+        parent::tearDown();
+    }
+
+    private function limparAmbiente(): void
+    {
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+        Team::truncate();
+        Training::truncate();
+        TeamsUsers::truncate();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
     }
 
     /**
@@ -647,16 +672,16 @@ class TrainingTest extends TestCase
 
         $this->be(User::find(3));
 
+        $team = Team::factory()->hasPlayers(10)->create();
+
         $training = Training::factory()
             ->setStatus($parameters['status'])
-            ->make();
+            ->make([
+                'team_id' => $team->id,
+            ]);
         $training->save();
 
         $parameters['id'] = $training->id;
-
-        $team = Team::factory()
-            ->hasPlayers(10)
-            ->create();
 
         $user = $team->players->first();
 

--- a/tests/Feature/GraphQL/TrainingTest.php
+++ b/tests/Feature/GraphQL/TrainingTest.php
@@ -246,7 +246,7 @@ class TrainingTest extends TestCase
         $team = Team::factory()
             ->create();
 
-        if($parameters['sendEmailPlayer']) {
+        if ($parameters['sendEmailPlayer']) {
             $player = $team->players()->first();
 
             $setting = $player->notificationSettings()
@@ -261,7 +261,7 @@ class TrainingTest extends TestCase
             }
         }
 
-        if($parameters['sendEmailTechnician']) {
+        if ($parameters['sendEmailTechnician']) {
             $technician = $team->technicians()->first();
 
             $setting = $technician->notificationSettings()

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -60,6 +60,7 @@ class UserTest extends TestCase
         Team::truncate();
         PositionsUsers::truncate();
         User::where('id', '>', 5)->forceDelete();
+        Position::truncate();
 
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -4,17 +4,17 @@ namespace Tests\Feature\GraphQL;
 
 use App\Models\NotificationType;
 use App\Models\Position;
+use App\Models\PositionsUsers;
 use App\Models\Team;
-use App\Models\User;
-use Faker\Factory as Faker;
-use Tests\TestCase;
-use Illuminate\Support\Facades\DB;
 use App\Models\TeamsUsers;
 use App\Models\Training;
-use App\Models\PositionsUsers;
+use App\Models\User;
 use App\Models\UserInformation;
-use Database\Seeders\Tenants\UserTableSeeder;
 use Database\Seeders\Tenants\PositionTableSeeder;
+use Database\Seeders\Tenants\UserTableSeeder;
+use Faker\Factory as Faker;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
 
 class UserTest extends TestCase
 {
@@ -279,7 +279,6 @@ class UserTest extends TestCase
             false,
             true
         );
-        
 
         $this->assertMessageError($typeMessageError, $response, $hasPermission, $expectedMessage);
 

--- a/tests/Feature/GraphQL/UserTest.php
+++ b/tests/Feature/GraphQL/UserTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\GraphQL;
 
+use App\Models\NotificationType;
 use App\Models\Position;
 use App\Models\Team;
-use App\Models\NotificationType;
 use App\Models\User;
 use Faker\Factory as Faker;
 use Tests\TestCase;


### PR DESCRIPTION
### O que?

Criado mais duas opções na API de registro de times, adicionar relacionamento de categoria e level de time.

### Por quê?

Bom para incrementar mais informações no registro de times.

### Testes Funcionais

![image](https://github.com/user-attachments/assets/32022ef6-0787-462a-b3de-b572d81b0004)

### Capturas de tela

![image](https://github.com/user-attachments/assets/eaa4bd05-66d2-40a7-a6f5-e813b6a2e3c8)

### Verificações

- [ ] Lembrete: Ajustar o `composer.json` com a versão.

